### PR TITLE
Reformatted changelog dates

### DIFF
--- a/options.html
+++ b/options.html
@@ -112,7 +112,7 @@ khanacademy.org</textarea>
 			<p>The extension will add a Habit to your <a href="https://habitrpg.com/">HabitRPG</a> user entitled "Browsing Productivity" so you can see how often you are punished or rewarded for your browsing habits.</p>
 			
 			<h4>Changelog v0.1.5</h4>
-			<h5>12/02/2013</h5>
+			<h5>Feb 12, 2013</h5>
 			
 			<ul>
 			<li>Added cloud storage saving thanks to <a href="https://github.com/ashjolliffe">@AshJolliffe</a> - Log into your Google Account in Chrome to use.</li>
@@ -122,7 +122,7 @@ khanacademy.org</textarea>
 			</ul>
 						
 			<h4>Changelog v0.1.4</h4>
-			<h5>10/02/2013</h5>
+			<h5>Feb 10, 2013</h5>
 			<ul>
 			<li>Added CSS styles to most elements thanks to <a href="https://github.com/cgardner">@cgardner</a></li>
 			<li>Fixed requiring restart after first input of UID & APIToken - <a href="https://github.com/cgardner">@cgardner</a> again.</li>


### PR DESCRIPTION
At least in the US, 10/02/2013 means Oct 2nd, 2013. 
I changed the format to something more universally recognizable. 
