### PR TITLE
Bugfix: Fix 'Extension Bugs' link in popup

### DIFF
--- a/common/html/popup.html
+++ b/common/html/popup.html
@@ -81,7 +81,7 @@
       <ul class="nav nav-pills nav-stacked">
         <li><a href="http://www.habitica.com" target="_blank">Habitica</a></li>
         <li><a target="_blank" href="http://habitica.tumblr.com/">Blog</a></li>
-        <li><a target="_blank" href="https://github.com/Habitica/habitica-chrome/issues">Extension Bugs</a></li>
+        <li><a target="_blank" href="https://github.com/HabitRPG/habitrpg-chrome/issues">Extension Bugs</a></li>
         <li><a href="options.html" target="_blank">Options</a></li>
       </ul>
 


### PR DESCRIPTION
Pointed at a nonexistent URL before.  (https://github.com/Habitica/habitica-chrome/)