### PR TITLE
Support multi-level domains and sub-domain preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ All grunt command must be writen to the terminal (cmd on windows) in the root of
       grunt watch:chrome # continuous watch the chrome dependency folders 
                          # and run the chrome command on every save
                      
-If these not enough for you check the grunt file it has some others and of course fill free to expand :)
+If these not enough for you check the grunt file it has some others and of course feel free to expand :)


### PR DESCRIPTION
By 1) using regex to grab the whole domain and 2) comparing the whole domain, and then comparing each level of that domain in a sub-domain-removing order, we are able to support multi-level domains such as "google.com.br" sites, as well as sub-domain-preferred sites (e.g. "facebook.com" in the bad, "developers.facebook.com" in the good).

